### PR TITLE
Support decode message from Buffer object

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -222,7 +222,7 @@ function RpcBuilder(packer, options, transport, onRequest)
 
   function transportMessage(event)
   {
-    self.decode(event.data || event);
+    self.decode(event.data || event.toString());
   };
 
   this.getTransport = function()


### PR DESCRIPTION
This is PR to fix Kurento/bugtracker#116 .
It makes decoding message from Buffer object. It depends on the behavior is changed by version up of websocket-stream.

To use in Kurento-client-js, It should be merged at the same time;
https://github.com/KurentoForks/reconnect-ws/pull/1