### PR TITLE
npm install kurento-client failed because this package used ancient p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,18 +67,17 @@
   },
   "devDependencies": {
     "bower": "~1.7.9",
-    "coveralls": "~2.11.1",
+    "browserify": "~13.1.0",
+    "coveralls": "^3.0.2",
     "eventtarget": "0.1.0",
     "grunt": "~1.0.1",
-    "grunt-browserify": "~5.0.0",
+    "grunt-browserify": "^5.3.0",
     "grunt-cli": "~1.2.0",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-jsdoc": "~2.2.1",
     "grunt-npm2bower-sync": "^0.9.0",
     "grunt-shell": "^2.0.0",
-    "jscoverage": "~0.6.0",
-    "browserify": "~13.1.0",
     "minifyify": "~7.3.3",
-    "nodeunit": "~0.10.2"
+    "nodeunit": "^0.11.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "test": "nodeunit test/index.js"
   },
   "dependencies": {
-    "inherits": "^2.0.1",
-    "ws": "^1.1.1",
-    "bufferutil": "1.2.x",
-    "utf-8-validate": "1.2.x"
+    "inherits": "^2.0.3",
+    "ws": "^6.1",
+    "bufferutil": "4.0",
+    "utf-8-validate": "^5.0"
   },
   "devDependencies": {
     "bower": "~1.7.9",

--- a/package.json
+++ b/package.json
@@ -66,12 +66,9 @@
     "utf-8-validate": "^5.0"
   },
   "devDependencies": {
-    "bower": "~1.7.9",
-    "browserify": "~13.1.0",
     "coveralls": "^3.0.2",
     "eventtarget": "0.1.0",
     "grunt": "~1.0.1",
-    "grunt-browserify": "^5.3.0",
     "grunt-cli": "~1.2.0",
     "grunt-contrib-clean": "~1.0.0",
     "grunt-jsdoc": "~2.2.1",


### PR DESCRIPTION
npm install kurento-client failed because this package used ancient package dependencies. Updated inherits, ws, bufferutil, utf-8-validate