### PR TITLE
update utf-8-validate to the latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,10 +60,10 @@
     "test": "nodeunit test/index.js"
   },
   "dependencies": {
-    "inherits": "^2.0.1",
-    "ws": "^1.1.1",
     "bufferutil": "1.2.x",
-    "utf-8-validate": "1.2.x"
+    "inherits": "^2.0.1",
+    "utf-8-validate": "^5.0.2",
+    "ws": "^1.1.1"
   },
   "devDependencies": {
     "bower": "~1.7.9",


### PR DESCRIPTION
utf-8-validate uses 'nan'. The older versions use 'ForceSet' that has been removed from new Node.js. Update to the latest version allows the package to be used with newer versions of Node.js.